### PR TITLE
A suggestion for a simpler approach.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -235,12 +235,6 @@ public interface CertificateClient extends Closeable {
   void registerNotificationReceiver(CertificateNotification receiver);
 
   /**
-   * Notify all certificate renewal receivers that the certificate is renewed.
-   *
-   */
-  void notifyNotificationReceivers(String oldCaCertId, String newCaCertId);
-
-  /**
    * Registers a listener that will be notified if the CA certificates are
    * changed.
    *

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -981,8 +981,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * Notify all certificate renewal receivers that the certificate is renewed.
    *
    */
-  @Override
-  public void notifyNotificationReceivers(String oldCaCertId,
+  protected void notifyNotificationReceivers(String oldCaCertId,
       String newCaCertId) {
     synchronized (notificationReceivers) {
       notificationReceivers.forEach(r -> r.notifyCertificateRenewed(

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClientTestImpl.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClientTestImpl.java
@@ -389,15 +389,6 @@ public class CertificateClientTestImpl implements CertificateClient {
   }
 
   @Override
-  public void notifyNotificationReceivers(String oldCaCertId,
-      String newCaCertId) {
-    synchronized (notificationReceivers) {
-      notificationReceivers.forEach(
-          n -> n.notifyCertificateRenewed(this, oldCaCertId, newCaCertId));
-    }
-  }
-
-  @Override
   public void registerRootCARotationListener(
       Function<List<X509Certificate>, CompletableFuture<Void>> listener) {
     // we do not have tests that rely on rootCA rotation atm, leaving this

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
@@ -112,8 +112,4 @@ public interface SCMHAManager extends AutoCloseable {
    */
   TermIndex installCheckpoint(DBCheckpoint dbCheckpoint) throws Exception;
 
-  /**
-   * Refresh Root CA certificate.
-   */
-  void refreshRootCACertificates() throws IOException;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -19,12 +19,9 @@ package org.apache.hadoop.hdds.scm.ha;
 
 import com.google.common.base.Preconditions;
 
-import java.security.cert.X509Certificate;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.protocolPB.SecretKeyProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.RemoveSCMRequest;
@@ -35,9 +32,6 @@ import org.apache.hadoop.hdds.scm.security.SecretKeyManagerService;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.SecurityConfig;
 import org.apache.hadoop.hdds.security.symmetric.ManagedSecretKey;
-import org.apache.hadoop.hdds.security.x509.certificate.authority.CAType;
-import org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient;
-import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.utils.HAUtils;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -289,45 +283,6 @@ public class SCMHAManagerImpl implements SCMHAManager {
         checkpointTrxnInfo);
 
     return installCheckpoint(checkpointLocation, checkpointTrxnInfo);
-  }
-
-  @Override
-  public void refreshRootCACertificates() throws IOException {
-    if (scm.getScmContext().isLeader() ||
-        scm.getScmCertificateClient() == null) {
-      return;
-    }
-    // In case root CA certificate is rotated during this SCM is offline
-    // period, fetch the new root CA list from leader SCM and refresh ratis
-    // server's tlsConfig.
-    SCMCertificateClient scmCertClient =
-        (SCMCertificateClient) scm.getScmCertificateClient();
-    SCMSecurityProtocolClientSideTranslatorPB scmSecurityClient =
-        scmCertClient.getScmSecureClient();
-    List<String> rootCAPems = scmSecurityClient.getAllRootCaCertificates();
-
-    // SCM certificate client sets root CA as CA cert instead of root CA cert
-    Set<X509Certificate> certList = scmCertClient.getAllRootCaCerts();
-    certList = certList.isEmpty() ? scmCertClient.getAllCaCerts() : certList;
-
-    List<X509Certificate> rootCAsFromLeaderSCM =
-        OzoneSecurityUtil.convertToX509(rootCAPems);
-    rootCAsFromLeaderSCM.removeAll(certList);
-
-    if (rootCAsFromLeaderSCM.isEmpty()) {
-      return;
-    }
-
-    for (X509Certificate cert : rootCAsFromLeaderSCM) {
-      LOG.info("Fetched new root CA certificate {} from leader SCM",
-          cert.getSerialNumber().toString());
-      scmCertClient.storeCertificate(
-          CertificateCodec.getPEMEncodedString(cert), CAType.SUBORDINATE);
-    }
-
-    String scmCertId =
-        scmCertClient.getCertificate().getSerialNumber().toString();
-    scmCertClient.notifyNotificationReceivers(scmCertId, scmCertId);
   }
 
   public TermIndex installCheckpoint(Path checkpointLocation,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerStub.java
@@ -165,10 +165,6 @@ public final class SCMHAManagerStub implements SCMHAManager {
     return null;
   }
 
-  @Override
-  public void refreshRootCACertificates() throws IOException {
-  }
-
   private class RatisServerStub implements SCMRatisServer {
 
     private Map<RequestType, Object> handlers =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -279,7 +279,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private ReplicationManager replicationManager;
 
   private SCMSafeModeManager scmSafeModeManager;
-  private CertificateClient scmCertificateClient;
+  private SCMCertificateClient scmCertificateClient;
   private RootCARotationManager rootCARotationManager;
   private ContainerTokenSecretManager containerTokenMgr;
 
@@ -955,15 +955,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     return scmCertificateClient;
   }
 
-  @VisibleForTesting
-  public void setScmCertificateClient(CertificateClient client)
-      throws IOException {
-    if (scmCertificateClient != null) {
-      scmCertificateClient.close();
-    }
-    scmCertificateClient = client;
-  }
-
   public Clock getSystemClock() {
     return systemClock;
   }
@@ -1543,7 +1534,12 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     // At this point leader is not known
     scmHAMetricsUpdate(null);
 
-    scmHAManager.refreshRootCACertificates();
+    if (scmContext.isLeader() && scmCertificateClient != null) {
+      // In case root CA certificate is rotated during this SCM is offline
+      // period, fetch the new root CA list from leader SCM and refresh ratis
+      // server's tlsConfig.
+      scmCertificateClient.refreshCACertificates();
+    }
   }
 
   /**


### PR DESCRIPTION
Please take a look on this approach, where we do not publish the notification sender method to the world from the certificate client, but handle it internally for SCM.

It is easier to show how I would solve this problem via sharing the idea of just relying on the certificate client to handle the whole refresh.

Let me know what do you think about the approach.
